### PR TITLE
Allow selection of user by organisation

### DIFF
--- a/src/api/endpoints.cr
+++ b/src/api/endpoints.cr
@@ -3,6 +3,7 @@ require "./endpoints/*"
 module Tanda::CLI
   module API
     module Endpoints
+      include Endpoints::Me
       include Endpoints::Shift
     end
   end

--- a/src/api/endpoints/me.cr
+++ b/src/api/endpoints/me.cr
@@ -1,0 +1,15 @@
+require "./interface.cr"
+require "../client"
+
+module Tanda::CLI
+  module API
+    module Endpoints::Me
+      include Endpoints::Interface
+
+      def me : Types::Me::Core
+        response = get("/users/me")
+        Types::Me::Core.from_json(response.body)
+      end
+    end
+  end
+end

--- a/src/cli/commands/current_user.cr
+++ b/src/cli/commands/current_user.cr
@@ -1,0 +1,64 @@
+require "colorize"
+
+module Tanda::CLI
+  module CLI::Commands
+    class CurrentUser
+      def initialize(client : API::Client, config : Configuration, id_or_name : String?)
+        @client = client
+        @config = config
+        @id_or_name = id_or_name
+      end
+
+      def execute
+        puts "\n"
+
+        id_or_name = self.id_or_name
+        return display_current_user if id_or_name.nil?
+
+        try_set_new_current_user!(id_or_name)
+      end
+
+      private getter client
+      private getter config
+      private getter id_or_name
+
+      private def display_current_user
+        if organisation = config.organisations.find(&.current?)
+          puts "The current user is #{display(organisation)}"
+        else
+          puts "A current user hasn't been set!"
+        end
+      end
+
+      private def try_set_new_current_user!(id_or_name : String)
+        maybe_user_id = id_or_name.to_i32?
+        organisation = config.organisations.find do |org|
+          if maybe_user_id
+            org.user_id == maybe_user_id
+          else
+            name = org.name.downcase
+            input_name = id_or_name.downcase
+
+            name.includes?(input_name)
+          end
+        end
+
+        return user_not_found! if organisation.nil?
+
+        config.organisations.each { |org| org.current = false }
+        organisation.current = true
+        config.save!
+
+        puts "The current user has been set to #{display(organisation)}"
+      end
+
+      private def user_not_found!
+        puts "#{"Error:".colorize(:red)} Invalid argument \"#{id_or_name}\""
+      end
+
+      private def display(organisation : Configuration::Organisation)
+        "#{organisation.user_id} in #{organisation.name}"
+      end
+    end
+  end
+end

--- a/src/cli/commands/current_user.cr
+++ b/src/cli/commands/current_user.cr
@@ -45,7 +45,7 @@ module Tanda::CLI
 
         return user_not_found! if organisation.nil?
 
-        config.organisations.each { |org| org.current = false }
+        config.organisations.each(&.current = false)
         organisation.current = true
         config.save!
 

--- a/src/cli/commands/time_zone.cr
+++ b/src/cli/commands/time_zone.cr
@@ -1,0 +1,54 @@
+module Tanda::CLI
+  module CLI::Commands
+    class TimeZone
+      def initialize(config : Configuration, new_time_zone : String?)
+        @config = config
+        @new_time_zone = new_time_zone
+      end
+
+      def execute
+        puts "\n"
+
+        if new_time_zone
+          set_time_zone
+        else
+          display_time_zone
+        end
+      end
+
+      private getter config : Configuration
+      private getter new_time_zone : String?
+
+      private def new_time_zone! : String
+        new_time_zone.not_nil!
+      end
+
+      private def display_time_zone
+        if time_zone = config.time_zone
+          puts "The current time zone is #{config.time_zone}"
+        else
+          puts "A time zone isn't currently set"
+          puts "Set it with `tanda_cli time_zone --set <time_zone>`"
+        end
+      end
+
+      private def set_time_zone
+        validate_time_zone!
+
+        new_time_zone = new_time_zone!
+        config.time_zone = new_time_zone
+        config.save!
+
+        puts "Successfully set current time zone to \"#{new_time_zone}\""
+      end
+
+      private def validate_time_zone!
+        new_time_zone = new_time_zone!
+        Time::Location.load(new_time_zone)
+      rescue Time::Location::InvalidLocationNameError
+        puts "#{"Error:".colorize(:red)} Invalid time zone \"#{new_time_zone}\""
+        exit
+      end
+    end
+  end
+end

--- a/src/cli/commands/time_zone.cr
+++ b/src/cli/commands/time_zone.cr
@@ -9,8 +9,8 @@ module Tanda::CLI
       def execute
         puts "\n"
 
-        if new_time_zone
-          set_time_zone
+        if time_zone = new_time_zone
+          set_time_zone!(time_zone)
         else
           display_time_zone
         end
@@ -18,10 +18,6 @@ module Tanda::CLI
 
       private getter config : Configuration
       private getter new_time_zone : String?
-
-      private def new_time_zone! : String
-        new_time_zone.not_nil!
-      end
 
       private def display_time_zone
         if time_zone = config.time_zone
@@ -32,21 +28,19 @@ module Tanda::CLI
         end
       end
 
-      private def set_time_zone
-        validate_time_zone!
+      private def set_time_zone!(time_zone : String)
+        validate_time_zone!(time_zone)
 
-        new_time_zone = new_time_zone!
-        config.time_zone = new_time_zone
+        config.time_zone = time_zone
         config.save!
 
         puts "Successfully set current time zone to \"#{new_time_zone}\""
       end
 
-      private def validate_time_zone!
-        new_time_zone = new_time_zone!
-        Time::Location.load(new_time_zone)
+      private def validate_time_zone!(time_zone : String)
+        Time::Location.load(time_zone)
       rescue Time::Location::InvalidLocationNameError
-        puts "#{"Error:".colorize(:red)} Invalid time zone \"#{new_time_zone}\""
+        puts "#{"Error:".colorize(:red)} Invalid time zone \"#{time_zone}\""
         exit
       end
     end

--- a/src/cli/commands/time_zone.cr
+++ b/src/cli/commands/time_zone.cr
@@ -21,7 +21,7 @@ module Tanda::CLI
 
       private def display_time_zone
         if time_zone = config.time_zone
-          puts "The current time zone is #{config.time_zone}"
+          puts "The current time zone is #{time_zone}"
         else
           puts "A time zone isn't currently set"
           puts "Set it with `tanda_cli time_zone --set <time_zone>`"

--- a/src/cli/current_user.cr
+++ b/src/cli/current_user.cr
@@ -18,8 +18,6 @@ module Tanda::CLI
       user ||= user_from_api
 
       Current.set_user!(user)
-
-      save_config!
     end
 
     private getter client : API::Client
@@ -41,6 +39,7 @@ module Tanda::CLI
       end
 
       organisation.current = true
+      save_config!
       Current::User.new(id: organisation.user_id, time_zone: time_zone)
     end
 

--- a/src/cli/current_user.cr
+++ b/src/cli/current_user.cr
@@ -31,11 +31,11 @@ module Tanda::CLI
     end
 
     private def user_from_api : Current::User
-      organisations = api_organisations
       organisation : Configuration::Organisation? = nil
+      organisations = api_organisations
 
       while organisation.nil?
-        organisation = request_organisation_from_user(api_organisations)
+        organisation = request_organisation_from_user(organisations)
       end
 
       organisation.current = true
@@ -47,7 +47,7 @@ module Tanda::CLI
       organisations = api_organisations
 
       puts "Which organisation would you like to use?"
-      api_organisations.each_with_index(1) do |org, index|
+      organisations.each_with_index(1) do |org, index|
         puts "#{index}: #{org.name}"
       end
       puts "\nEnter a number: "

--- a/src/cli/current_user.cr
+++ b/src/cli/current_user.cr
@@ -1,0 +1,91 @@
+require "colorize"
+
+require "../api/client"
+require "../configuration"
+
+module Tanda::CLI
+  class CLI::CurrentUser
+    @api_organisations : Array(Configuration::Organisation)?
+    @me : Types::Me::Core?
+    @time_zone : String?
+
+    def initialize(client : API::Client, config : Configuration)
+      @client = client
+      @config = config
+    end
+
+    def set!
+      user = user_from_config
+      user ||= user_from_api
+
+      Current.set_user!(user)
+
+      save_config!
+    end
+
+    private getter client : API::Client
+    private getter config : Configuration
+
+    private def user_from_config : Current::User?
+      organisation = config.organisations.find(&.current?)
+      return if organisation.nil?
+
+      Current::User.new(id: organisation.user_id, time_zone: time_zone)
+    end
+
+    private def user_from_api : Current::User
+      organisations = api_organisations
+      organisation : Configuration::Organisation? = nil
+
+      while organisation.nil?
+        organisation = request_organisation_from_user(api_organisations)
+      end
+
+      organisation.current = true
+      Current::User.new(id: organisation.user_id, time_zone: time_zone)
+    end
+
+    def me : Types::Me::Core
+      @me ||= client.me
+    end
+
+    def time_zone : String
+      @time_zone ||= config.time_zone || me.time_zone
+    end
+
+    def api_organisations : Array(Configuration::Organisation)
+      @api_organisations ||= client.me.organisations.map do |org|
+        Configuration::Organisation.from_json(org.to_json)
+      end
+    end
+
+    def request_organisation_from_user(organistations : Array(Configuration::Organisation)) : Configuration::Organisation?
+      organisations = api_organisations
+
+      puts "Which organisation would you like to use?"
+      api_organisations.each_with_index(1) do |org, index|
+        puts "#{index}: #{org.name}"
+      end
+      puts "\nEnter a number: "
+      user_input = gets
+      user_input = user_input.chomp if user_input
+      number = user_input ? user_input.to_i32? : nil
+
+      if number
+        organisations[number - 1]?
+      else
+        if user_input
+          puts "\nInvalid selection \"#{user_input}\"\n"
+        else
+          puts "\nYou must select a number\n"
+        end
+      end
+    end
+
+    def save_config!
+      config.time_zone ||= time_zone
+      config.organisations = api_organisations
+      config.save!
+    end
+  end
+end

--- a/src/cli/current_user.cr
+++ b/src/cli/current_user.cr
@@ -7,7 +7,6 @@ module Tanda::CLI
   class CLI::CurrentUser
     @api_organisations : Array(Configuration::Organisation)?
     @me : Types::Me::Core?
-    @time_zone : String?
 
     def initialize(client : API::Client, config : Configuration)
       @client = client
@@ -45,21 +44,7 @@ module Tanda::CLI
       Current::User.new(id: organisation.user_id, time_zone: time_zone)
     end
 
-    def me : Types::Me::Core
-      @me ||= client.me
-    end
-
-    def time_zone : String
-      @time_zone ||= config.time_zone || me.time_zone
-    end
-
-    def api_organisations : Array(Configuration::Organisation)
-      @api_organisations ||= client.me.organisations.map do |org|
-        Configuration::Organisation.from_json(org.to_json)
-      end
-    end
-
-    def request_organisation_from_user(organistations : Array(Configuration::Organisation)) : Configuration::Organisation?
+    private def request_organisation_from_user(organistations : Array(Configuration::Organisation)) : Configuration::Organisation?
       organisations = api_organisations
 
       puts "Which organisation would you like to use?"
@@ -82,10 +67,24 @@ module Tanda::CLI
       end
     end
 
-    def save_config!
+    private def save_config!
       config.time_zone ||= time_zone
       config.organisations = api_organisations
       config.save!
+    end
+
+    private def me : Types::Me::Core
+      @me ||= client.me
+    end
+
+    private def time_zone : String
+      config.time_zone || me.time_zone
+    end
+
+    private def api_organisations : Array(Configuration::Organisation)
+      @api_organisations ||= client.me.organisations.map do |org|
+        Configuration::Organisation.from_json(org.to_json)
+      end
     end
   end
 end

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -49,6 +49,18 @@ module Tanda::CLI
 
           CLI::Commands::TimeZone.new(config, new_time_zone).execute
         end
+
+        parser.on("current_user", "Display the current user") do
+          new_id_or_name : String? = nil
+
+          OptionParser.parse do |set_user_parser|
+            set_user_parser.on("--set=ID_OR_NAME", "Set the current user") do |id_or_name|
+              new_id_or_name = id_or_name
+            end
+          end
+
+          CLI::Commands::CurrentUser.new(client, config, new_id_or_name).execute
+        end
       end
     end
 

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -12,8 +12,7 @@ module Tanda::CLI
     def parse!
       OptionParser.parse do |parser|
         parser.on("me", "Get your own information") do
-          response = client.get("/users/me").body
-          me = Types::Me::Core.from_json(response)
+          me = client.me
           Representers::Me::Core.new(me).display
         end
 

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -1,3 +1,6 @@
+require "colorize"
+
+require "./commands/**"
 require "../current"
 require "../api/client"
 require "../representers/**"
@@ -5,8 +8,9 @@ require "../types/**"
 
 module Tanda::CLI
   class CLI::Parser
-    def initialize(client : API::Client)
+    def initialize(client : API::Client, config : Configuration)
       @client = client
+      @config = config
     end
 
     def parse!
@@ -32,6 +36,18 @@ module Tanda::CLI
 
             handle_time_worked_week(list)
           end
+        end
+
+        parser.on("time_zone", "See the currently set time zone") do
+          new_time_zone : String? = nil
+
+          OptionParser.parse do |set_time_zone_parser|
+            set_time_zone_parser.on("--set=TIME_ZONE", "Set the current time zone") do |time_zone|
+              new_time_zone = time_zone
+            end
+          end
+
+          CLI::Commands::TimeZone.new(config, new_time_zone).execute
         end
       end
     end
@@ -83,5 +99,6 @@ module Tanda::CLI
     end
 
     private getter client : API::Client
+    private getter config : Configuration
   end
 end

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -5,16 +5,46 @@ require "./types/access_token"
 
 module Tanda::CLI
   class Configuration
+    DEFAULT_SITE_PREFIX = "eu"
+
+    DEFAULT_ACCESS_TOKEN = {
+      "email": nil,
+      "token": nil,
+      "token_type": nil,
+      "scope": nil,
+      "created_at": nil
+    }
+
+    DEFAULT_ORGANISATIONS = [] of Organisation
+
     DEFAULT_CONFIG = {
-      "site_prefix": "eu",
-      "access_token": {
-        "email": nil,
-        "token": nil,
-        "token_type": nil,
-        "scope": nil,
-        "created_at": nil
-      }
-    }.to_json
+      "site_prefix": DEFAULT_SITE_PREFIX,
+      "access_token": DEFAULT_ACCESS_TOKEN,
+      "organisations": DEFAULT_ORGANISATIONS
+    }
+
+    class Organisation
+      include JSON::Serializable
+
+      # defaults
+      @current : Bool = false
+
+      @[JSON::Field(key: "id")]
+      getter id : Int32
+
+      @[JSON::Field(key: "name")]
+      getter name : String
+
+      @[JSON::Field(key: "user_id")]
+      getter user_id : Int32
+
+      @[JSON::Field(key: "current")]
+      property current : Bool
+
+      def current? : Bool
+        current
+      end
+    end
 
     class AccessToken
       include JSON::Serializable
@@ -38,21 +68,40 @@ module Tanda::CLI
     class Config
       include JSON::Serializable
 
+      # defaults
+      @site_prefix   : String              = DEFAULT_SITE_PREFIX
+      @access_token  : AccessToken         = AccessToken.from_json(DEFAULT_ACCESS_TOKEN.to_json)
+      @organisations : Array(Organisation) = Array(Organisation).from_json(DEFAULT_ORGANISATIONS.to_json)
+
       @[JSON::Field(key: "site_prefix")]
       property site_prefix : String
 
       @[JSON::Field(key: "access_token")]
       property access_token : AccessToken
+
+      @[JSON::Field(key: "organisations")]
+      property organisations : Array(Organisation)
+
+      @[JSON::Field(key: "time_zone")]
+      property time_zone : String?
     end
 
     def initialize
-      @config = Config.from_json(DEFAULT_CONFIG)
+      @config = Config.from_json(DEFAULT_CONFIG.to_json)
     end
 
-    delegate site_prefix, access_token, to: config
+    delegate site_prefix, access_token, organisations, time_zone, to: config
 
     def site_prefix=(value : String)
       config.site_prefix = value
+    end
+
+    def organisations=(value : Array(Organisation))
+      config.organisations = value
+    end
+
+    def time_zone=(value : String)
+      config.time_zone = value
     end
 
     def parse_config!

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -1,4 +1,5 @@
 # shards
+require "colorize"
 require "option_parser"
 
 # internal
@@ -8,13 +9,23 @@ require "./api/**"
 require "./cli/**"
 
 module Tanda::CLI
+  def self.try_parse_config!(config : Configuration)
+    config.parse_config!
+  rescue error
+    {% if flag?(:debug) %}
+      raise(error)
+    {% else %}
+      puts "\n#{"Error:".colorize(:red)} Invalid Config!"
+      puts error.message.try(&.split("\n").first) if error.is_a?(JSON::SerializableError)
+      exit
+    {% end %}
+  end
+
   def self.main
     config = Configuration.new
-    config.parse_config!
-    token = config.access_token.token
+    try_parse_config!(config)
 
-    # TODO: Don't hard code User
-    Current.set_user!(Current::User.new(id: 66585, time_zone: "Europe/London"))
+    token = config.access_token.token
 
     # if a token can't be parsed from the config, get username and password from user and request a token
     if token.nil?
@@ -30,6 +41,7 @@ module Tanda::CLI
     token = config.token!
     client = API::Client.new(url, token)
 
+    CLI::CurrentUser.new(client, config).set!
     CLI::Parser.new(client).parse!
   end
 end

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -42,7 +42,7 @@ module Tanda::CLI
     client = API::Client.new(url, token)
 
     CLI::CurrentUser.new(client, config).set!
-    CLI::Parser.new(client).parse!
+    CLI::Parser.new(client, config).parse!
   end
 end
 

--- a/src/types/me/core.cr
+++ b/src/types/me/core.cr
@@ -11,6 +11,9 @@ module Tanda::CLI
         @[JSON::Field(key: "email")]
         getter email : String
 
+        @[JSON::Field(key: "time_zone")]
+        getter time_zone : String
+
         @[JSON::Field(key: "user_ids")]
         getter user_ids : Array(Int32)
 


### PR DESCRIPTION
Now stores organisations in config from /users/me which can also now be selected for the `user_id` needed for requests

Adds new commands
```sh
# displays the current time zone
tanda_cli time_zone

# allows you to set a new time zone
tanda_cli time_zone --set Europe/London

# displays the current user being used in requests
tanda_cli current_user

# allows the current user to be set
# with a user_id as the argument
tanda_cli current_user --set 12345
# with the organisation name as the argument
tanda_cli current_user --set "Moe's Tavern"
```