### PR TITLE
Rough clockin support

### DIFF
--- a/spec/current_spec.cr
+++ b/spec/current_spec.cr
@@ -6,18 +6,18 @@ Spectator.describe Tanda::CLI::Current do
   end
 
   context "Current user" do
-    it "Raises when Current.user! is called without a user set" do
+    it "Raises when Current.user is called without a user set" do
       expect_raises Tanda::CLI::Current::UserNotSet do
-        Tanda::CLI::Current.user!
+        Tanda::CLI::Current.user
       end
     end
 
     context "Setting user" do
       let(user) { Tanda::CLI::Current::User.new(id: 1, time_zone: "Europe/London") }
 
-      it "Returns set user when calling Current.user!" do
+      it "Returns set user when calling Current.user" do
         Tanda::CLI::Current.set_user!(user)
-        expect(Tanda::CLI::Current.user!).to eq(user)
+        expect(Tanda::CLI::Current.user).to eq(user)
       end
 
       it "Raises when Current.set_user! is called a second time" do

--- a/src/api/client.cr
+++ b/src/api/client.cr
@@ -10,6 +10,7 @@ module Tanda::CLI
       include Tanda::CLI::API::Endpoints
 
       alias TQuery = Hash(String, String)
+      alias TBody  = Hash(String, String)
 
       def initialize(base_uri : String, token : String)
         @base_uri = base_uri
@@ -20,6 +21,15 @@ module Tanda::CLI
         uri = build_uri(endpoint, query)
 
         response = HTTP::Client.get(uri, headers: build_headers)
+        Log.debug(&.emit("Response", body: response.body))
+
+        response
+      end
+
+      def post(endpoint : String, body : TBody) : HTTP::Client::Response
+        uri = build_uri(endpoint)
+
+        response = HTTP::Client.post(uri, headers: build_headers, body: body.to_json)
         Log.debug(&.emit("Response", body: response.body))
 
         response

--- a/src/api/endpoints.cr
+++ b/src/api/endpoints.cr
@@ -3,6 +3,7 @@ require "./endpoints/*"
 module Tanda::CLI
   module API
     module Endpoints
+      include Endpoints::ClockIn
       include Endpoints::Me
       include Endpoints::Shift
     end

--- a/src/api/endpoints/clock_in.cr
+++ b/src/api/endpoints/clock_in.cr
@@ -1,0 +1,20 @@
+require "./interface.cr"
+require "../client"
+
+module Tanda::CLI
+  module API
+    module Endpoints::ClockIn
+      include Endpoints::Interface
+
+      def send_clockin(time : Time, type : String) : Bool
+        response = post("/clockins", body: {
+          "time" => time.to_unix.to_s,
+          "type" => type,
+          "user_id" => Current.user.id.to_s
+        })
+
+        response.success?
+      end
+    end
+  end
+end

--- a/src/api/endpoints/interface.cr
+++ b/src/api/endpoints/interface.cr
@@ -2,6 +2,7 @@ module Tanda::CLI
   module API
     module Endpoints::Interface
       abstract def get(endpoint : String, query : TQuery? = nil) : HTTP::Client::Response
+      abstract def post(endpoint : String, body : TBody) : HTTP::Client::Response
     end
   end
 end

--- a/src/api/endpoints/shift.cr
+++ b/src/api/endpoints/shift.cr
@@ -22,7 +22,7 @@ module Tanda::CLI
         .map(&.to_s("%Y-%m-%d"))
 
         response = get("/shifts", query: {
-          "user_ids" => Current.user!.id.to_s,
+          "user_ids" => Current.user.id.to_s,
           "from"     => start_string,
           "to"       => finish_string
         })

--- a/src/cli/commands/clock_in.cr
+++ b/src/cli/commands/clock_in.cr
@@ -1,0 +1,15 @@
+module Tanda::CLI
+  module CLI::Commands
+    class ClockIn
+      def initialize(@client : API::Client, @clock_type : String); end
+
+      def execute
+        now = Time.local(location: Current.user.time_zone)
+        client.send_clockin(now, clock_type)
+      end
+
+      private getter client
+      private getter clock_type
+    end
+  end
+end

--- a/src/cli/commands/clock_in.cr
+++ b/src/cli/commands/clock_in.cr
@@ -4,7 +4,7 @@ module Tanda::CLI
       def initialize(@client : API::Client, @clock_type : String); end
 
       def execute
-        now = Time.local(location: Current.user.time_zone)
+        now = Utils::Time.now
         client.send_clockin(now, clock_type)
       end
 

--- a/src/cli/commands/time_worked/today.cr
+++ b/src/cli/commands/time_worked/today.cr
@@ -5,7 +5,7 @@ module Tanda::CLI
     module TimeWorked
       class Today < Base
         def execute
-          now = Time.local(location: Current.user.time_zone)
+          now = Utils::Time.now
           shifts = client.shifts(now)
           total_time_worked = calculate_time_worked(shifts)
 

--- a/src/cli/commands/time_worked/today.cr
+++ b/src/cli/commands/time_worked/today.cr
@@ -5,7 +5,7 @@ module Tanda::CLI
     module TimeWorked
       class Today < Base
         def execute
-          now = Time.local
+          now = Time.local(location: Current.user.time_zone)
           shifts = client.shifts(now)
           total_time_worked = calculate_time_worked(shifts)
 

--- a/src/cli/commands/time_worked/week.cr
+++ b/src/cli/commands/time_worked/week.cr
@@ -5,7 +5,7 @@ module Tanda::CLI
     module TimeWorked
       class Week < Base
         def execute
-          now = Time.local(location: Current.user.time_zone)
+          now = Utils::Time.now
           shifts = client.shifts(now.at_beginning_of_week, now)
           total_time_worked = calculate_time_worked(shifts)
 

--- a/src/cli/commands/time_worked/week.cr
+++ b/src/cli/commands/time_worked/week.cr
@@ -5,7 +5,7 @@ module Tanda::CLI
     module TimeWorked
       class Week < Base
         def execute
-          now = Time.local
+          now = Time.local(location: Current.user.time_zone)
           shifts = client.shifts(now.at_beginning_of_week, now)
           total_time_worked = calculate_time_worked(shifts)
 

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -59,6 +59,14 @@ module Tanda::CLI
 
           CLI::Commands::CurrentUser.new(client, config, new_id_or_name).execute
         end
+
+        parser.on("clockin", "Clock in/out") do
+          OptionParser.parse do |clock_flag|
+            clock_flag.on("--type=TYPE", "Clock type - start | finish") do |clock_type|
+              CLI::Commands::ClockIn.new(client, clock_type).execute
+            end
+          end
+        end
       end
     end
 

--- a/src/current.cr
+++ b/src/current.cr
@@ -23,7 +23,7 @@ module Tanda::CLI
       end
     end
 
-    delegate user!, to: instance
+    delegate user, to: instance
 
     def set_user!(user : User)
       raise UserAlreadySet.new if @@user_set
@@ -44,25 +44,25 @@ module Tanda::CLI
     end
 
     private class CurrentInstance
-      getter user : User?
+      getter maybe_user : User?
 
       def initialize
-        @user = nil
+        @maybe_user = nil
       end
 
       def user=(user : User)
-        @user = user
+        @maybe_user = user
       end
 
-      def user! : User
-        nilable_user = user
+      def user : User
+        nilable_user = maybe_user
         raise UserNotSet.new unless nilable_user
 
         nilable_user
       end
 
       def reset!
-        @user = nil
+        @maybe_user = nil
       end
     end
   end

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -4,7 +4,7 @@ require "option_parser"
 # internal
 require "./configuration"
 require "./current"
-require "./utils/display"
+require "./utils/**"
 require "./api/**"
 require "./cli/**"
 

--- a/src/types/converters/time.cr
+++ b/src/types/converters/time.cr
@@ -8,14 +8,14 @@ module Tanda::CLI
           timestamp = value.read_int_or_null
           return unless timestamp
 
-          ::Time.unix(timestamp.to_i32).in(Current.user!.time_zone)
+          ::Time.unix(timestamp.to_i32).in(Current.user.time_zone)
         end
       end
 
       module FromISODate
         def self.from_json(value : JSON::PullParser) : ::Time
           date = value.read_string
-          ::Time.parse(date, "%Y-%m-%d", Current.user!.time_zone)
+          ::Time.parse(date, "%Y-%m-%d", Current.user.time_zone)
         end
       end
     end

--- a/src/types/shift.cr
+++ b/src/types/shift.cr
@@ -68,7 +68,7 @@ module Tanda::CLI
         s = start
         return if s.nil?
 
-        now = Time.local(location: Current.user.time_zone)
+        now = Utils::Time.now
         return unless now.date == s.date
 
         (now - s) - total_break_minutes

--- a/src/types/shift.cr
+++ b/src/types/shift.cr
@@ -68,7 +68,7 @@ module Tanda::CLI
         s = start
         return if s.nil?
 
-        now = Time.local(Time::Location.load("Europe/London"))
+        now = Time.local(location: Current.user.time_zone)
         return unless now.date == s.date
 
         (now - s) - total_break_minutes

--- a/src/utils/time.cr
+++ b/src/utils/time.cr
@@ -1,0 +1,11 @@
+module Tanda::CLI
+  module Utils
+    module Time
+      extend self
+
+      def now : ::Time
+        ::Time.local(location: Current.user.time_zone)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds rough clockin support clocking in and clocking out

```sh
tanda_cli clockin --type start
tanda_cli clockin --type finish
```

This will very likely be refactored later for better usability