### PR TITLE
Bump Crystal to 1.6.2

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: crystallang/crystal:1.6.1
+      image: crystallang/crystal:1.6.2
 
     steps:
     - uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.6.1
+crystal 1.6.2

--- a/shard.yml
+++ b/shard.yml
@@ -16,6 +16,6 @@ development_dependencies:
     gitlab: arctic-fox/spectator # https://gitlab.com/arctic-fox/spectator
     version: ~> 0.11.3
 
-crystal: 1.6.1
+crystal: 1.6.2
 
 license: MIT


### PR DESCRIPTION
https://crystal-lang.org/2022/11/03/1.6.2-released.html