### PR TITLE
Enable lint rules that are disabled by default in ameba

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,3 +1,22 @@
+# Exclusions
 Lint/DebugCalls:
   Excluded:
     - src/debug.cr
+
+# Disabled by default
+Layout/LineLength:
+  Enabled: true
+  MaxLength: 140 # default
+
+Lint/ComparisonToBoolean:
+  Enabled: true
+
+Style/GuardClause:
+  Enabled: true
+
+Style/LargeNumbers:
+  Enabled: true
+  IntMinDigits: 5 # i.e. integers higher than 9999
+
+Style/PredicateName:
+  Enabled: true


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13454550/200323754-f45f0800-5b56-46b0-85dc-a7ceda2e4647.png)