### PR TITLE
Add `API::Result` API

### DIFF
--- a/src/api/auth.cr
+++ b/src/api/auth.cr
@@ -11,7 +11,7 @@ module Tanda::CLI
     module Auth
       extend self
 
-      def fetch_access_token!(site_prefix : String, email : String, password : String) : Types::AccessToken | Types::Error
+      def fetch_access_token!(site_prefix : String, email : String, password : String) : API::Result(Types::AccessToken)
         response = HTTP::Client.post(
           build_endpoint(site_prefix),
           headers: build_headers,
@@ -25,7 +25,8 @@ module Tanda::CLI
 
         Log.debug(&.emit("Response", body: response.body))
 
-        (response.success? ? Types::AccessToken : Types::Error).from_json(response.body)
+        result = (response.success? ? Types::AccessToken : Types::Error).from_json(response.body)
+        API::Result(Types::AccessToken).new(result)
       end
 
       private def build_endpoint(site_prefix : String) : String

--- a/src/api/endpoints/clock_in.cr
+++ b/src/api/endpoints/clock_in.cr
@@ -6,15 +6,15 @@ module Tanda::CLI
     module Endpoints::ClockIn
       include Endpoints::Interface
 
-      def send_clock_in(time : Time, type : String) : Types::Error?
+      def send_clock_in(time : Time, type : String) : API::Result(Nil)
         response = post("/clockins", body: {
           "time" => time.to_unix.to_s,
           "type" => type,
           "user_id" => Current.user.id.to_s
         })
-        return if response.success?
 
-        Types::Error.from_json(response.body)
+        result = Types::Error.from_json(response.body) unless response.success?
+        API::Result(Nil).new(result)
       end
     end
   end

--- a/src/api/result.cr
+++ b/src/api/result.cr
@@ -3,33 +3,27 @@ require "../types/error"
 module Tanda::CLI
   module API
     class Result(T)
-      class Matcher(T)
-        def initialize(@value : T | Types::Error); end
-
-        def ok(&block : T -> ::Nil)
-          value = self.value
-          return if value.is_a?(Types::Error)
-
-          yield(value)
-        end
-
-        def error(&block : Types::Error -> ::Nil)
-          value = self.value
-          return unless value.is_a?(Types::Error)
-
-          yield(value)
-        end
-
-        private getter value : T | Types::Error
-      end
-
       def initialize(@value : T | Types::Error); end
 
       def match(&block)
-        with Matcher(T).new(value) yield
+        with self yield
       end
 
       private getter value : T | Types::Error
+
+      private def ok(&block : T -> ::Nil)
+        value = self.value
+        return if value.is_a?(Types::Error)
+
+        yield(value)
+      end
+
+      private def error(&block : Types::Error -> ::Nil)
+        value = self.value
+        return unless value.is_a?(Types::Error)
+
+        yield(value)
+      end
     end
   end
 end

--- a/src/api/result.cr
+++ b/src/api/result.cr
@@ -6,8 +6,6 @@ module Tanda::CLI
       class Matcher(T)
         def initialize(@value : T | Types::Error); end
 
-        getter value : T | Types::Error
-
         def ok(&block : T -> ::Nil)
           value = self.value
           return if value.is_a?(Types::Error)
@@ -21,15 +19,17 @@ module Tanda::CLI
 
           yield(value)
         end
+
+        private getter value : T | Types::Error
       end
 
       def initialize(@value : T | Types::Error); end
 
-      getter value : T | Types::Error
-
       def match(&block)
         with Matcher(T).new(value) yield
       end
+
+      private getter value : T | Types::Error
     end
   end
 end

--- a/src/api/result.cr
+++ b/src/api/result.cr
@@ -1,0 +1,35 @@
+require "../types/error"
+
+module Tanda::CLI
+  module API
+    class Result(T)
+      class Matcher(T)
+        def initialize(@value : T | Types::Error); end
+
+        getter value : T | Types::Error
+
+        def ok(&block : T -> ::Nil)
+          value = self.value
+          return if value.is_a?(Types::Error)
+
+          yield(value)
+        end
+
+        def error(&block : Types::Error -> ::Nil)
+          value = self.value
+          return unless value.is_a?(Types::Error)
+
+          yield(value)
+        end
+      end
+
+      def initialize(@value : T | Types::Error); end
+
+      getter value : T | Types::Error
+
+      def match(&block)
+        with Matcher(T).new(value) yield
+      end
+    end
+  end
+end

--- a/src/cli/commands/clock_in.cr
+++ b/src/cli/commands/clock_in.cr
@@ -7,12 +7,14 @@ module Tanda::CLI
 
       def execute
         now = Utils::Time.now
-        error = client.send_clock_in(now, clock_type.to_underscore)
+        client.send_clock_in(now, clock_type.to_underscore).match do
+          ok do
+            display_success_message
+          end
 
-        if error
-          Utils::Display.error(error)
-        else
-          display_success_message
+          error do |error|
+            Utils::Display.error(error)
+          end
         end
       end
 

--- a/src/types/access_token.cr
+++ b/src/types/access_token.cr
@@ -1,8 +1,10 @@
-require "./base"
+require "json"
 
 module Tanda::CLI
   module Types
-    class AccessToken < Base
+    class AccessToken
+      include JSON::Serializable
+
       @[JSON::Field(key: "access_token")]
       getter token : String
 

--- a/src/types/base.cr
+++ b/src/types/base.cr
@@ -1,9 +1,0 @@
-require "json"
-
-module Tanda::CLI
-  module Types
-    abstract class Base
-      include JSON::Serializable
-    end
-  end
-end

--- a/src/types/error.cr
+++ b/src/types/error.cr
@@ -1,8 +1,10 @@
-require "./base"
+require "json"
 
 module Tanda::CLI
   module Types
-    class Error < Base
+    class Error
+      include JSON::Serializable
+
       @error_description : String? = nil
 
       @[JSON::Field(key: "error")]

--- a/src/types/me/core.cr
+++ b/src/types/me/core.cr
@@ -1,10 +1,12 @@
+require "json"
 require "./organisation"
-require "../base"
 
 module Tanda::CLI
   module Types
     module Me
-      class Core < Base
+      class Core
+        include JSON::Serializable
+
         @[JSON::Field(key: "name")]
         getter name : String
 

--- a/src/types/me/organisation.cr
+++ b/src/types/me/organisation.cr
@@ -1,9 +1,10 @@
-require "../base"
+require "json"
 
 module Tanda::CLI
   module Types
     module Me
-      class Organisation < Base
+      class Organisation
+        include JSON::Serializable
         @[JSON::Field(key: "id")]
         getter id : Int32
 

--- a/src/types/shift.cr
+++ b/src/types/shift.cr
@@ -1,10 +1,12 @@
-require "./base"
+require "json"
 require "./shift_break"
 require "./converters/time"
 
 module Tanda::CLI
   module Types
-    class Shift < Base
+    class Shift
+      include JSON::Serializable
+
       DEFAULT_DATE_FORMAT = "%A, %d %b %Y"
 
       enum Status

--- a/src/types/shift_break.cr
+++ b/src/types/shift_break.cr
@@ -1,9 +1,11 @@
-require "./base"
+require "json"
 require "./converters/time"
 
 module Tanda::CLI
   module Types
-    class ShiftBreak < Base
+    class ShiftBreak
+      include JSON::Serializable
+
       @[JSON::Field(key: "id")]
       getter id : Int32
 


### PR DESCRIPTION
API for handling requests that might fail

Example
```crystal
def fetch_shift(id : Int32) : API::Result(Types::Shift)
  ...

  API::Result(Types::Shift).new(result)
end

...

fetch_shift(1).match do
  ok do |shift|
    Utils::Display.success("Successfully retrieved shift #{shift.id}!")
  end

  error do |error|
    Utils::Display.error(error)
    exit
  end
end
```