### PR TITLE
Allow commands to be run in staging or development env

### DIFF
--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -6,9 +6,28 @@ require "../types/**"
 
 module Tanda::CLI
   class CLI::Parser
-    def initialize(@client : API::Client, @config : Configuration, @args = ARGV); end
+    def initialize(@config : Configuration, @args = ARGV); end
 
     def parse!
+      # Options that don't need a client or current user set
+      OptionParser.parse(args) do |parser|
+        parser.on("time_zone", "See the currently set time zone") do
+          CLI::Parser::TimeZone.new(parser, config).parse
+        end
+
+        parser.on("current_user", "Display the current user") do
+          CLI::Parser::CurrentUser.new(parser, config).parse
+        end
+
+        parser.on("mode", "Set the mode to run commands in (production/staging/custom <url>") do
+          CLI::Parser::Mode.new(parser, config).parse
+        end
+      end.parse
+
+      client = create_client_from_config
+      CLI::CurrentUser.new(client, config).set!
+
+      # Options that need a client to make API requests
       OptionParser.parse(args) do |parser|
         parser.on("me", "Get your own information") do
           me = client.me
@@ -22,23 +41,51 @@ module Tanda::CLI
         parser.on("clockin", "Clock in/out") do
           CLI::Parser::ClockIn.new(parser, client).parse
         end
-
-        parser.on("time_zone", "See the currently set time zone") do
-          CLI::Parser::TimeZone.new(parser, config).parse
-        end
-
-        parser.on("current_user", "Display the current user") do
-          CLI::Parser::CurrentUser.new(parser, config).parse
-        end
-
-        parser.on("mode", "Set the mode to run commands in (production/staging/custom <url>") do
-          CLI::Parser::Mode.new(parser, config).parse
-        end
       end
     end
 
-    private getter args : Array(String)
-    private getter client : API::Client
     private getter config : Configuration
+    private getter args   : Array(String)
+
+    private def create_client_from_config : API::Client
+      token = config.access_token.token
+
+      # if a token can't be parsed from the config, get username and password from user and request a token
+      if token.nil?
+        site_prefix, email, password = CLI::Auth.request_user_information!
+
+        auth_site_prefix = if config.staging?
+          case site_prefix
+          when "my"
+            "staging"
+          when "eu"
+            "staging.eu"
+          when "us"
+            "staging.us"
+          end
+        end || site_prefix
+
+        API::Auth.fetch_access_token!(auth_site_prefix, email, password).match do
+          ok do |access_token|
+            Utils::Display.success("Retrieved token!#{config.staging? && " (staging)"}\n")
+            config.overwrite!(site_prefix, email, access_token)
+          end
+
+          error do |error|
+            Utils::Display.error("Unable to authenticate (likely incorrect login details)")
+            Utils::Display.sub_error("Error Type: #{error.error}")
+
+            description = error.error_description
+            Utils::Display.sub_error("Message: #{description}") if description
+
+            exit
+          end
+        end
+      end
+
+      url = config.get_api_url
+      token = config.token!
+      API::Client.new(url, token)
+    end
   end
 end

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -30,6 +30,10 @@ module Tanda::CLI
         parser.on("current_user", "Display the current user") do
           CLI::Parser::CurrentUser.new(parser, config).parse
         end
+
+        parser.on("mode", "Set the mode to run commands in (production/staging/custom <url>") do
+          CLI::Parser::Mode.new(parser, config).parse
+        end
       end
     end
 

--- a/src/cli/parser/current_user.cr
+++ b/src/cli/parser/current_user.cr
@@ -18,6 +18,7 @@ module Tanda::CLI
         end
 
         CLI::Commands::CurrentUser.new(config, new_id_or_name, list).execute
+        exit
       end
 
       private getter parser : OptionParser

--- a/src/cli/parser/mode.cr
+++ b/src/cli/parser/mode.cr
@@ -11,6 +11,7 @@ module Tanda::CLI
           config.save!
 
           Utils::Display.success("Successfully set mode to production!")
+          exit
         end
 
         parser.on("staging", "Set mode to staging") do
@@ -18,6 +19,7 @@ module Tanda::CLI
           config.save!
 
           Utils::Display.success("Successfully set mode to staging!")
+          exit
         end
 
         parser.on("--custom=CUSTOM", "Set mode to custom URL") do |custom|
@@ -43,6 +45,7 @@ module Tanda::CLI
 
         parser.on("current", "View currently set mode") do
           puts "Mode is currently set to #{config.mode}"
+          exit
         end
       end
 

--- a/src/cli/parser/mode.cr
+++ b/src/cli/parser/mode.cr
@@ -37,7 +37,7 @@ module Tanda::CLI
           config.mode = uri_string
           config.save!
 
-          Utils::Display.success("Successfully saved custom url!", uri_string)
+          Utils::Display.success("Successfully set custom url", uri_string)
           exit
         end
 

--- a/src/cli/parser/mode.cr
+++ b/src/cli/parser/mode.cr
@@ -48,13 +48,6 @@ module Tanda::CLI
 
       private getter parser
       private getter config
-
-      private def invalid_host?(uri : URI) : Bool
-        host = uri.host
-        return true if host.nil?
-
-
-      end
     end
   end
 end

--- a/src/cli/parser/mode.cr
+++ b/src/cli/parser/mode.cr
@@ -1,0 +1,60 @@
+require "uri"
+
+module Tanda::CLI
+  class CLI::Parser
+    class Mode
+      def initialize(@parser : OptionParser, @config : Configuration); end
+
+      def parse
+        parser.on("production", "Set mode to production") do
+          config.mode = "production"
+          config.save!
+
+          Utils::Display.success("Successfully set mode to production!")
+        end
+
+        parser.on("staging", "Set mode to staging") do
+          config.mode = "staging"
+          config.save!
+
+          Utils::Display.success("Successfully set mode to staging!")
+        end
+
+        parser.on("--custom=CUSTOM", "Set mode to custom URL") do |custom|
+          if custom.blank?
+            Utils::Display.error("Must pass an argument to custom")
+            exit
+          end
+
+          uri = Configuration.validate_url(custom)
+
+          if uri.is_a?(String)
+            Utils::Display.error(uri, custom)
+            exit
+          end
+
+          uri_string = uri.to_s
+          config.mode = uri_string
+          config.save!
+
+          Utils::Display.success("Successfully saved custom url!", uri_string)
+          exit
+        end
+
+        parser.on("current", "View currently set mode") do
+          puts "Mode is currently set to #{config.mode}"
+        end
+      end
+
+      private getter parser
+      private getter config
+
+      private def invalid_host?(uri : URI) : Bool
+        host = uri.host
+        return true if host.nil?
+
+
+      end
+    end
+  end
+end

--- a/src/cli/parser/time_zone.cr
+++ b/src/cli/parser/time_zone.cr
@@ -13,6 +13,7 @@ module Tanda::CLI
         end
 
         CLI::Commands::TimeZone.new(config, new_time_zone).execute
+        exit
       end
 
       private getter parser : OptionParser

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -203,6 +203,7 @@ module Tanda::CLI
     end
 
     private getter config : Config
+    private getter staging : Bool
 
     private def config_dir : String
       @config_dir ||= "#{Path.home}/.tanda_cli"

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -108,6 +108,7 @@ module Tanda::CLI
     def self.validate_url(url : String) : URI | ErrorString
       uri = URI.parse(url).normalize!
       return "Invalid URL" if uri.opaque?
+      return "URL must be prefixed with \"https://\"" if uri.scheme != "https"
       return "URL cannot contain query parameters" if uri.query
 
       host = uri.host

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -28,31 +28,30 @@ module Tanda::CLI
     config = Configuration.new
     try_parse_config!(config)
 
-    mode = config.mode
+    if config.staging?
+      Utils::Display.warning("Running command on #{config.mode}\n")
+    end
+
     token = config.access_token.token
 
     # if a token can't be parsed from the config, get username and password from user and request a token
     if token.nil?
       site_prefix, email, password = CLI::Auth.request_user_information!
 
-      staging = mode != "production"
-      if staging
-        site_prefix =
-          case site_prefix
-          when "my"
-            "staging"
-          when "eu"
-            "staging.eu"
-          when "us"
-            "staging.us"
-          else
-            site_prefix
-          end
-      end
+      auth_site_prefix = if config.staging?
+        case site_prefix
+        when "my"
+          "staging"
+        when "eu"
+          "staging.eu"
+        when "us"
+          "staging.us"
+        end
+      end || site_prefix
 
-      API::Auth.fetch_access_token!(site_prefix, email, password).match do
+      API::Auth.fetch_access_token!(auth_site_prefix, email, password).match do
         ok do |access_token|
-          Utils::Display.success("Retrieved token!#{staging && " (staging)"}\n")
+          Utils::Display.success("Retrieved token!#{config.staging? && " (staging)"}\n")
           config.overwrite!(site_prefix, email, access_token)
         end
 

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -32,47 +32,7 @@ module Tanda::CLI
       Utils::Display.warning("Running command on #{config.mode}\n")
     end
 
-    token = config.access_token.token
-
-    # if a token can't be parsed from the config, get username and password from user and request a token
-    if token.nil?
-      site_prefix, email, password = CLI::Auth.request_user_information!
-
-      auth_site_prefix = if config.staging?
-        case site_prefix
-        when "my"
-          "staging"
-        when "eu"
-          "staging.eu"
-        when "us"
-          "staging.us"
-        end
-      end || site_prefix
-
-      API::Auth.fetch_access_token!(auth_site_prefix, email, password).match do
-        ok do |access_token|
-          Utils::Display.success("Retrieved token!#{config.staging? && " (staging)"}\n")
-          config.overwrite!(site_prefix, email, access_token)
-        end
-
-        error do |error|
-          Utils::Display.error("Unable to authenticate (likely incorrect login details)")
-          Utils::Display.sub_error("Error Type: #{error.error}")
-
-          description = error.error_description
-          Utils::Display.sub_error("Message: #{description}") if description
-
-          exit
-        end
-      end
-    end
-
-    url = config.get_api_url
-    token = config.token!
-    client = API::Client.new(url, token)
-
-    CLI::CurrentUser.new(client, config).set!
-    CLI::Parser.new(client, config).parse!
+    CLI::Parser.new(config).parse!
   end
 end
 

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -53,7 +53,7 @@ module Tanda::CLI
       API::Auth.fetch_access_token!(site_prefix, email, password).match do
         ok do |access_token|
           Utils::Display.success("Retrieved token!#{staging && " (staging)"}\n")
-          config.overwrite!(site_prefix, email, access_token, staging: staging)
+          config.overwrite!(site_prefix, email, access_token)
         end
 
         error do |error|

--- a/src/tanda_cli.cr
+++ b/src/tanda_cli.cr
@@ -28,10 +28,6 @@ module Tanda::CLI
     config = Configuration.new
     try_parse_config!(config)
 
-    if config.staging?
-      Utils::Display.warning("Running command on #{config.mode}\n")
-    end
-
     CLI::Parser.new(config).parse!
   end
 end

--- a/src/utils/display.cr
+++ b/src/utils/display.cr
@@ -6,15 +6,21 @@ module Tanda::CLI
       extend self
 
       SUCCESS_STRING = "Success:".colorize(:green)
+      WARNING_STRING = "Warning:".colorize(:yellow)
       ERROR_STRING = "Error:".colorize(:red)
 
       enum Type
         Success
+        Warning
         Error
       end
 
       def success(message : String, value = nil)
         display_message(Type::Success, message, value)
+      end
+
+      def warning(message : String)
+        display_message(Type::Warning, message)
       end
 
       def error(message : String, value = nil)
@@ -41,6 +47,8 @@ module Tanda::CLI
         case type
         in Type::Success
           SUCCESS_STRING
+        in Type::Warning
+          WARNING_STRING
         in Type::Error
           ERROR_STRING
         end


### PR DESCRIPTION
Adds a new `mode` option

```sh
# sets API calls to be made to staging.tanda.co
tanda_cli mode staging

# Default mode: sets API calls to be made to my.tanda.co
tanda_cli mode production
```