### PR TITLE
Ask for organisation after refetching token

### DIFF
--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -67,6 +67,10 @@ module Tanda::CLI
         parser.on("refetch_token", "Refetch token for the current environment") do
           config.reset_environment!
           fetch_new_token!
+
+          client = create_client_from_config
+          CLI::Request.ask_which_organisation_and_save!(client, config)
+          exit
         end
 
         parser.on("refetch_users", "Refetch users from the API and save to config") do

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -48,20 +48,20 @@ module Tanda::CLI
     private def parse_api_options!
       OptionParser.parse(args) do |parser|
         parser.on("me", "Get your own information") do
-          me = client.me.or(&.display!)
+          me = build_client_with_current_user.me.or(&.display!)
           Representers::Me.new(me).display
         end
 
         parser.on("time_worked", "See how many hours you've worked") do
-          CLI::Parser::TimeWorked.new(parser, client).parse
+          CLI::Parser::TimeWorked.new(parser, build_client_with_current_user).parse
         end
 
         parser.on("clockin", "Clock in/out") do
-          CLI::Parser::ClockIn.new(parser, client).parse
+          CLI::Parser::ClockIn.new(parser, build_client_with_current_user).parse
         end
 
         parser.on("balance", "Check your leave balances") do
-          CLI::Parser::LeaveBalance.new(parser, client).parse
+          CLI::Parser::LeaveBalance.new(parser, build_client_with_current_user).parse
         end
 
         parser.on("refetch_token", "Refetch token for the current environment") do
@@ -74,13 +74,13 @@ module Tanda::CLI
         end
 
         parser.on("refetch_users", "Refetch users from the API and save to config") do
-          CLI::Request.ask_which_organisation_and_save!(client, config)
+          CLI::Request.ask_which_organisation_and_save!(build_client_with_current_user, config)
           exit
         end
       end
     end
 
-    private def client : API::Client
+    private def build_client_with_current_user : API::Client
       @client ||= begin
         client = create_client_from_config
         CLI::CurrentUser.new(client, config).set!

--- a/src/cli/parser.cr
+++ b/src/cli/parser.cr
@@ -107,10 +107,12 @@ module Tanda::CLI
       token = config.access_token.token
 
       # if a token can't be parsed from the config, get username and password from user and request a token
-      fetch_new_token! if token.nil?
+      if token.nil?
+        fetch_new_token!
+        return create_client_from_config
+      end
 
       url = config.api_url
-      token = config.token!
       API::Client.new(url, token)
     end
 

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -164,13 +164,6 @@ module Tanda::CLI
       config.mode = value
     end
 
-    def token! : String
-      token = access_token.token
-      Utils::Display.fatal!("Token is missing") if token.nil?
-
-      token
-    end
-
     def overwrite!(site_prefix : String, email : String, access_token : Types::AccessToken)
       self.site_prefix = site_prefix
       self.access_token.email = email


### PR DESCRIPTION
When using the `refetch_token` command you would go through the process of getting a new token which is all fine and dandy. The problem is when you use another command that needs to make an API request, you will then be asked to pick an organisation which is kind of jarring. Now we ask after successfully retrieving a token