### PR TITLE
Improve output for most commands

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -6,7 +6,7 @@ Lint/DebugCalls:
 # Disabled by default
 Layout/LineLength:
   Enabled: true
-  MaxLength: 140 # default
+  MaxLength: 180 # default
 
 Lint/ComparisonToBoolean:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ tanda_cli mode staging
 # This will take you through the auth flow allowing a different region to be selected as well
 tanda_cli refetch_token
 ```
+<img width="582" alt="image" src="https://user-images.githubusercontent.com/13454550/231261211-21a90d65-1580-4c04-8bbc-d9a4fe419419.png">
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ tanda_cli mode staging
 # This will take you through the auth flow allowing a different region to be selected as well
 tanda_cli refetch_token
 ```
-<img width="582" alt="image" src="https://user-images.githubusercontent.com/13454550/231261211-21a90d65-1580-4c04-8bbc-d9a4fe419419.png">
+<img width="454" alt="image" src="https://user-images.githubusercontent.com/13454550/231261971-a5fb9c80-2710-44e5-b6f4-b65673caa264.png">
 
 ## Development
 

--- a/src/cli/commands/time_worked/base.cr
+++ b/src/cli/commands/time_worked/base.cr
@@ -1,3 +1,5 @@
+require "colorize"
+
 module Tanda::CLI
   module CLI::Commands
     module TimeWorked
@@ -41,8 +43,8 @@ module Tanda::CLI
         end
 
         private def print_shift(shift : Types::Shift, time_worked : Time::Span?, worked_so_far : Time::Span?)
-          time_worked && puts "Time worked: #{time_worked.hours} hours and #{time_worked.minutes} minutes"
-          (!time_worked && worked_so_far) && puts "Worked so far: #{worked_so_far.hours} hours and #{worked_so_far.minutes} minutes"
+          time_worked && puts "#{"Time worked:".colorize.bold} #{time_worked.hours} hours and #{time_worked.minutes} minutes"
+          (!time_worked && worked_so_far) && puts "#{"Worked so far:".colorize.bold} #{worked_so_far.hours} hours and #{worked_so_far.minutes} minutes"
 
           Representers::Shift.new(shift).display
         end
@@ -53,7 +55,7 @@ module Tanda::CLI
           # Don't bother showing days where there are no hours for leave
           return if length.zero?
 
-          puts "Leave taken: #{length.hours} hours and #{length.minutes} minutes"
+          puts "#{"Leave taken:".colorize.bold} #{length.hours} hours and #{length.minutes} minutes"
 
           Representers::LeaveRequest::DailyBreakdown.new(breakdown, leave_request).display
         end

--- a/src/representers/base.cr
+++ b/src/representers/base.cr
@@ -22,8 +22,12 @@ module Tanda::CLI
 
       private abstract def build_display(builder : String::Builder)
 
-      protected def with_padding(key : String, value, builder : String::Builder)
-        builder << "    #{key}: #{value}\n"
+      protected def with_padding(value : String, builder : String::Builder)
+        builder << "    #{value}\n"
+      end
+
+      protected def titled_with_padding(title : String, value, builder : String::Builder)
+        with_padding("#{title}: #{value}", builder)
       end
 
       private getter object : T

--- a/src/representers/clock_in.cr
+++ b/src/representers/clock_in.cr
@@ -9,8 +9,8 @@ module Tanda::CLI
           titled_with_padding("ID", object.id, builder)
         {% end %}
 
-        titled_with_padding("Time", object.pretty_date_time, builder)
-        titled_with_padding("Type", object.type, builder)
+        with_padding("🕔 #{object.pretty_date_time}", builder)
+        with_padding("🤔 #{object.type}", builder)
       end
     end
   end

--- a/src/representers/clock_in.cr
+++ b/src/representers/clock_in.cr
@@ -6,11 +6,11 @@ module Tanda::CLI
     class ClockIn < Base(Types::ClockIn)
       private def build_display(builder : String::Builder)
         {% if flag?(:debug) %}
-          with_padding("ID", object.id, builder)
+          titled_with_padding("ID", object.id, builder)
         {% end %}
 
-        with_padding("Time", object.pretty_date_time, builder)
-        with_padding("Type", object.type, builder)
+        titled_with_padding("Time", object.pretty_date_time, builder)
+        titled_with_padding("Type", object.type, builder)
       end
     end
   end

--- a/src/representers/leave_balance.cr
+++ b/src/representers/leave_balance.cr
@@ -6,8 +6,8 @@ module Tanda::CLI
     class LeaveBalance < Base(Types::LeaveBalance)
       private def build_display(builder : String::Builder)
         builder << "Leave Balance\n"
-        titled_with_padding("Hours", object.pretty_hours, builder)
-        titled_with_padding("Leave Type", object.leave_type, builder)
+        with_padding("⏳ #{object.pretty_hours}", builder)
+        with_padding("🌴 #{object.leave_type}", builder)
       end
     end
   end

--- a/src/representers/leave_balance.cr
+++ b/src/representers/leave_balance.cr
@@ -6,8 +6,8 @@ module Tanda::CLI
     class LeaveBalance < Base(Types::LeaveBalance)
       private def build_display(builder : String::Builder)
         builder << "Leave Balance\n"
-        with_padding("Hours", object.pretty_hours, builder)
-        with_padding("Leave Type", object.leave_type, builder)
+        titled_with_padding("Hours", object.pretty_hours, builder)
+        titled_with_padding("Leave Type", object.leave_type, builder)
       end
     end
   end

--- a/src/representers/leave_request/daily_breakdown.cr
+++ b/src/representers/leave_request/daily_breakdown.cr
@@ -18,7 +18,7 @@ module Tanda::CLI
 
         start = object.start_time
         finish = object.finish_time
-        builder << "🕔 #{start} - #{finish}\n"
+        builder << "🕔 #{start} - #{finish}\n" if start || finish
 
         builder << "🚧 #{leave_request.status}\n"
         builder << "🌴 #{leave_request.leave_type}\n"

--- a/src/representers/leave_request/daily_breakdown.cr
+++ b/src/representers/leave_request/daily_breakdown.cr
@@ -14,16 +14,15 @@ module Tanda::CLI
           builder << "User ID: #{leave_request.user_id}\n"
         {% end %}
 
-        builder << "Date: #{object.pretty_date}\n"
+        builder << "📅 #{object.pretty_date}\n"
 
         start = object.start_time
-        builder << "Start: #{start}\n" if start
-
         finish = object.finish_time
-        builder << "Finish: #{finish}\n" if finish
 
-        builder << "Status: #{leave_request.status}\n"
-        builder << "Leave type: #{leave_request.leave_type}\n"
+        builder << "🕔 #{start} - #{finish}\n"
+
+        builder << "🚧 #{leave_request.status}\n"
+        builder << "🌴 #{leave_request.leave_type}\n"
       end
 
       private getter leave_request : Types::LeaveRequest

--- a/src/representers/leave_request/daily_breakdown.cr
+++ b/src/representers/leave_request/daily_breakdown.cr
@@ -18,7 +18,6 @@ module Tanda::CLI
 
         start = object.start_time
         finish = object.finish_time
-
         builder << "🕔 #{start} - #{finish}\n"
 
         builder << "🚧 #{leave_request.status}\n"

--- a/src/representers/me/organisation.cr
+++ b/src/representers/me/organisation.cr
@@ -7,13 +7,13 @@ module Tanda::CLI
       class Organisation < Base(Types::Me::Organisation)
         private def build_display(builder : String::Builder)
           {% if flag?(:debug) %}
-            with_padding("ID", object.id, builder)
-            with_padding("User ID", object.user_id, builder)
+            titled_with_padding("ID", object.id, builder)
+            titled_with_padding("User ID", object.user_id, builder)
           {% end %}
 
-          with_padding("Name", object.name, builder)
-          with_padding("Country", object.country, builder)
-          with_padding("Locale", object.locale, builder)
+          titled_with_padding("Name", object.name, builder)
+          titled_with_padding("Country", object.country, builder)
+          titled_with_padding("Locale", object.locale, builder)
         end
       end
     end

--- a/src/representers/shift.cr
+++ b/src/representers/shift.cr
@@ -18,8 +18,7 @@ module Tanda::CLI
 
         pretty_start = object.pretty_start_time
         pretty_finish = object.pretty_finish_time
-
-        builder << "🕓 #{pretty_start} - #{pretty_finish}\n"
+        builder << "🕓 #{pretty_start} - #{pretty_finish}\n" if pretty_start || pretty_finish
 
         builder << "🚧 #{object.status}\n"
 

--- a/src/representers/shift.cr
+++ b/src/representers/shift.cr
@@ -12,15 +12,14 @@ module Tanda::CLI
           builder << "User ID: #{object.user_id}\n"
         {% end %}
 
-        builder << "Date: #{object.pretty_date}\n"
+        builder << "📅 #{object.pretty_date}\n"
 
         pretty_start = object.pretty_start_time
-        builder << "Start: #{pretty_start}\n" if pretty_start
-
         pretty_finish = object.pretty_finish_time
-        builder << "Finish: #{pretty_finish}\n" if pretty_finish
 
-        builder << "Status: #{object.status}\n"
+        builder << "🕓 #{pretty_start} - #{pretty_finish}\n"
+
+        builder << "🚧 #{object.status}\n"
 
         display_shift_breaks(builder) if !object.valid_breaks.empty?
       end

--- a/src/representers/shift.cr
+++ b/src/representers/shift.cr
@@ -1,3 +1,5 @@
+require "colorize"
+
 require "./base"
 require "./shift_break"
 require "../types/shift"
@@ -25,7 +27,7 @@ module Tanda::CLI
       end
 
       private def display_shift_breaks(builder : String::Builder)
-        builder << "Breaks:\n"
+        builder << "Breaks:\n".colorize.bold
         object.valid_breaks.sort_by(&.id).each do |shift_break|
           builder << ShiftBreak.new(shift_break).build
         end

--- a/src/representers/shift_break.cr
+++ b/src/representers/shift_break.cr
@@ -7,18 +7,17 @@ module Tanda::CLI
     class ShiftBreak < Base(Types::ShiftBreak)
       private def build_display(builder : String::Builder)
         {% if flag?(:debug) %}
-          with_padding("ID", object.id, builder)
-          with_padding("Shift ID", object.shift_id, builder)
+          titled_with_padding("ID", object.id, builder)
+          titled_with_padding("Shift ID", object.shift_id, builder)
         {% end %}
 
         pretty_start = object.pretty_start_time
-        with_padding("Start", pretty_start, builder) if pretty_start
-
         pretty_finish = object.pretty_finish_time
-        with_padding("Finish", pretty_finish, builder) if pretty_finish
 
-        with_padding("Length", object.pretty_ongoing_length, builder)
-        with_padding("Paid", object.paid?, builder)
+        with_padding("🕓 #{pretty_start} - #{pretty_finish}", builder)
+
+        with_padding("⏸️  #{object.pretty_ongoing_length}", builder)
+        with_padding("💰 #{object.paid?}", builder)
       end
     end
   end

--- a/src/representers/shift_break.cr
+++ b/src/representers/shift_break.cr
@@ -13,8 +13,7 @@ module Tanda::CLI
 
         pretty_start = object.pretty_start_time
         pretty_finish = object.pretty_finish_time
-
-        with_padding("🕓 #{pretty_start} - #{pretty_finish}", builder)
+        with_padding("🕓 #{pretty_start} - #{pretty_finish}", builder) if pretty_start || pretty_finish
 
         with_padding("⏸️  #{object.pretty_ongoing_length}", builder)
         with_padding("💰 #{object.paid?}", builder)


### PR DESCRIPTION
General improvements to command output, making it more concise and easier to read

### Example - `time_worked` command
#### Before
<img width="590" alt="image" src="https://user-images.githubusercontent.com/13454550/231260390-290cbe42-8014-41c5-b775-041b068d30f6.png">

#### After
<img width="582" alt="image" src="https://user-images.githubusercontent.com/13454550/231261211-21a90d65-1580-4c04-8bbc-d9a4fe419419.png">
