### PR TITLE
Configure clockin photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ tanda_cli clockin status
 # Display clock ins for today
 tanda_cli clockin display
 
+# Configure clockin photo to be used on each clockin if not specified
+# View configured photo or directory of photos
+tanda_cli clockin photo view
+# Set configured photo or directory (if a directory a photo is randomly picked)
+tanda_cli clockin photo --set "/path/to/photo.png"
+# or
+tanda_cli clockin photo --set "/path/to/dir/with/photos/"
+# Clear configuration photo or directory
+tanda_cli clockin photo clear
+
 # Display leave balance information
 tanda_cli balance
 

--- a/src/cli/parser/clock_in.cr
+++ b/src/cli/parser/clock_in.cr
@@ -60,13 +60,15 @@ module Tanda::CLI
             config.clockin_photo_path = path
             config.save!
 
+            Utils::Display.success("\"Clockin photo set to #{path}\"")
+
             exit
           end
 
           parser.on("view", "View a clockin photo") do
             config = Current.config
-            if (path = config.clockin_photo_path)
-              puts "Clockin photo: #{config.clockin_photo_path}"
+            if path = config.clockin_photo_path
+              puts "Clockin photo: #{path}"
             else
               puts "No clockin photo set"
             end

--- a/src/cli/parser/clock_in.cr
+++ b/src/cli/parser/clock_in.cr
@@ -56,6 +56,10 @@ module Tanda::CLI
       def parse
         parser.on("photo", "View, set or clear clockin photo to be used by default") do
           parser.on("-s PHOTO", "--set=PHOTO", "Set a clockin photo") do |path|
+            if !Models::PhotoParser.valid?(path)
+              Utils::Display.error!("Invalid photo path")
+            end
+
             config = Current.config
             config.clockin_photo_path = path
             config.save!

--- a/src/cli/parser/clock_in.cr
+++ b/src/cli/parser/clock_in.cr
@@ -64,7 +64,7 @@ module Tanda::CLI
             config.clockin_photo_path = path
             config.save!
 
-            Utils::Display.success("\"Clock in photo set to #{path}\"")
+            Utils::Display.success("Clock in photo set to \"#{path}\"")
 
             exit
           end

--- a/src/cli/parser/clock_in.cr
+++ b/src/cli/parser/clock_in.cr
@@ -60,7 +60,7 @@ module Tanda::CLI
             config.clockin_photo_path = path
             config.save!
 
-            Utils::Display.success("\"Clockin photo set to #{path}\"")
+            Utils::Display.success("\"Clock in photo set to #{path}\"")
 
             exit
           end
@@ -68,9 +68,9 @@ module Tanda::CLI
           parser.on("view", "View a clockin photo") do
             config = Current.config
             if path = config.clockin_photo_path
-              puts "Clockin photo: #{path}"
+              puts "Clock in photo: #{path}"
             else
-              puts "No clockin photo set"
+              puts "No clock in photo set"
             end
 
             exit
@@ -80,6 +80,8 @@ module Tanda::CLI
             config = Current.config
             config.clockin_photo_path = nil
             config.save!
+
+            Utils::Display.success("Clock in photo cleared")
 
             exit
           end

--- a/src/configuration.cr
+++ b/src/configuration.cr
@@ -63,6 +63,7 @@ module Tanda::CLI
         super
       end
 
+      property clockin_photo_path : String?
       property site_prefix : String
       property access_token : AccessToken
       property organisations : Array(Organisation)
@@ -73,6 +74,7 @@ module Tanda::CLI
       include JSON::Serializable
 
       # defaults
+      @clockin_photo_path : String? = nil
       @production : Environment = Environment.new
       @staging : Environment = Environment.new
       @mode : String = "production"
@@ -85,6 +87,7 @@ module Tanda::CLI
 
       getter production
       getter staging
+      property clockin_photo_path : String?
       property mode : String
 
       def reset_staging!
@@ -121,7 +124,8 @@ module Tanda::CLI
 
     def initialize(@config : Config = Config.new); end
 
-    delegate mode, to: config
+    delegate clockin_photo_path, :clockin_photo_path=, to: config
+    delegate mode, :mode=, to: config
 
     # properties that return from a different environment depending on `mode`
     mode_property time_zone : String?
@@ -139,10 +143,6 @@ module Tanda::CLI
       else
         config.reset_production!
       end
-    end
-
-    def mode=(value : String)
-      config.mode = value
     end
 
     def overwrite!(site_prefix : String, email : String, access_token : Types::AccessToken)

--- a/src/models/photo.cr
+++ b/src/models/photo.cr
@@ -1,0 +1,99 @@
+module Tanda::CLI
+  module Models
+    class Photo
+      @base_64_encoded : (String | Error::Base)? = nil
+
+      ONE_MEGABYTE = 1 * 1024 * 1024
+
+      module Error
+        abstract class Base < Exception; end
+
+        class PhotoCantBeFound < Base
+          def initialize(path : String)
+            @message = "The file '#{path}' could not be found."
+          end
+        end
+
+        class PhotoTooLarge < Base
+          def initialize(photo_bytes : String)
+            @message = "Photo is over 1 MB (#{photo_bytes.bytesize} bytes)"
+          end
+        end
+
+        class UnsupportedPhotoFormat < Base
+          def initialize
+            @message = "Photo must be a JPEG or PNG."
+          end
+        end
+      end
+
+      def initialize(@path : String); end
+
+      def base_64_encoded : String | Error::Base
+        @base_64_encoded ||= begin
+          photo_bytes = read_and_validate_file
+          if photo_bytes.is_a?(Error::Base)
+            photo_bytes
+          else
+            encode_base_64(photo_bytes)
+          end
+        end
+      end
+
+      def valid? : Bool
+        base_64_encoded.is_a?(String)
+      end
+
+      private getter path : String
+
+      private def read_and_validate_file : String | Error::Base
+        photo_bytes = validate_file_exists || validate_file_type || read_file
+        return photo_bytes unless photo_bytes.is_a?(String)
+
+        validate_photo_size(photo_bytes) || photo_bytes
+      end
+
+      private def read_file : String | Error::PhotoCantBeFound
+        File.read(path)
+      rescue File::NotFoundError
+        Error::PhotoCantBeFound.new(path)
+      end
+
+      private def validate_file_type : Error::UnsupportedPhotoFormat?
+        return if jpeg? || png?
+
+        Error::UnsupportedPhotoFormat.new
+      end
+
+      private def validate_file_exists : Error::PhotoCantBeFound?
+        return if File.exists?(path)
+
+        Error::PhotoCantBeFound.new(path)
+      end
+
+      private def validate_photo_size(photo_bytes : String) : Error::Base?
+        return if photo_bytes.bytesize <= ONE_MEGABYTE
+
+        Error::PhotoTooLarge.new(photo_bytes)
+      end
+
+      private def encode_base_64(photo_bytes : String) : String | Error::Base
+        if jpeg?
+          "data:image/jpeg;base64,#{Base64.strict_encode(photo_bytes)}"
+        elsif png?
+          "data:image/png;base64,#{Base64.strict_encode(photo_bytes)}"
+        else
+          Error::UnsupportedPhotoFormat.new
+        end
+      end
+
+      private def jpeg? : Bool
+        path.ends_with?(".jpg") || path.ends_with?(".jpeg")
+      end
+
+      private def png? : Bool
+        path.ends_with?(".png")
+      end
+    end
+  end
+end

--- a/src/models/photo_directory.cr
+++ b/src/models/photo_directory.cr
@@ -1,0 +1,32 @@
+require "./photo"
+
+module Tanda::CLI
+  module Models
+    class PhotoDirectory
+      def initialize(@path : String); end
+
+      def sample_photo : Photo?
+        valid_photo.tap do |photo|
+          Utils::Display.warning("No valid photos found in #{@path}") if photo.nil?
+        end
+      end
+
+      private def valid_photo : Photo?
+        valid_photo : Photo? = nil
+
+        Dir.open(@path).children.shuffle.each do |photo_name|
+          path = path_with_dir(photo_name)
+          photo = Photo.new(path)
+
+          break valid_photo = photo if photo.valid?
+        end
+
+        valid_photo
+      end
+
+      private def path_with_dir(photo_name) : String
+        "#{@path}/#{photo_name}"
+      end
+    end
+  end
+end

--- a/src/models/photo_directory.cr
+++ b/src/models/photo_directory.cr
@@ -5,6 +5,10 @@ module Tanda::CLI
     class PhotoDirectory
       def initialize(@path : String); end
 
+      def valid? : Bool
+        Dir.exists?(@path) && valid_photo
+      end
+
       def sample_photo : Photo?
         valid_photo.tap do |photo|
           Utils::Display.warning("No valid photos found in #{@path}") if photo.nil?

--- a/src/models/photo_directory.cr
+++ b/src/models/photo_directory.cr
@@ -6,7 +6,7 @@ module Tanda::CLI
       def initialize(@path : String); end
 
       def valid? : Bool
-        Dir.exists?(@path) && valid_photo
+        Dir.exists?(@path) && !!valid_photo
       end
 
       def sample_photo : Photo?

--- a/src/models/photo_parser.cr
+++ b/src/models/photo_parser.cr
@@ -8,6 +8,13 @@ module Tanda::CLI
         def initialize(@message : String); end
       end
 
+      def self.valid?(path : String) : Bool
+        photo_or_dir = new(path).parse
+        return false if photo_or_dir.is_a?(InvalidPath)
+
+        photo_or_dir.valid?
+      end
+
       def initialize(@path : String)
         @path = path
       end

--- a/src/models/photo_parser.cr
+++ b/src/models/photo_parser.cr
@@ -1,0 +1,26 @@
+require "./photo"
+require "./photo_directory"
+
+module Tanda::CLI
+  module Models
+    class PhotoParser
+      class InvalidPath < Exception
+        def initialize(@message : String); end
+      end
+
+      def initialize(@path : String)
+        @path = path
+      end
+
+      def parse : Photo | PhotoDirectory | InvalidPath
+        if File.directory?(@path)
+          PhotoDirectory.new(@path)
+        elsif File.file?(@path)
+          Photo.new(@path)
+        else
+          InvalidPath.new("Invalid path: #{@path}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows a photo or directory with photos to be configured to be used on each clockin without specifying with `--photo` each time. In the case of a directory a random photo will be picked each time

Closes https://github.com/DanielGilchrist/tanda_cli/issues/82