### PR TITLE
Implement time left and overtime for time_worked commands

### DIFF
--- a/src/cli/commands/time_worked/base.cr
+++ b/src/cli/commands/time_worked/base.cr
@@ -45,7 +45,6 @@ module Tanda::CLI
             puts "#{"Time worked:".colorize.white.bold} #{time_worked.hours} hours and #{time_worked.minutes} minutes"
           elsif worked_so_far
             puts "#{"Worked so far:".colorize.white.bold} #{worked_so_far.hours} hours and #{worked_so_far.minutes} minutes"
-
             maybe_print_time_left_or_overtime(shift, worked_so_far)
           end
 

--- a/src/cli/commands/time_worked/base.cr
+++ b/src/cli/commands/time_worked/base.cr
@@ -46,26 +46,29 @@ module Tanda::CLI
           elsif worked_so_far
             puts "#{"Worked so far:".colorize.white.bold} #{worked_so_far.hours} hours and #{worked_so_far.minutes} minutes"
 
-            organisation = Current.config.current_environment.current_organisation!
-            regular_hours_schedule = organisation.regular_hours_schedules.try(&.find(&.day_of_week.==(shift.date.day_of_week)))
-
-            if regular_hours_schedule
-              break_length = begin
-                if regular_hours_schedule.breaks.any? { |regular_hours_break| break_past_current_time?(regular_hours_break) }
-                  regular_hours_schedule.break_length
-                else
-                  0.minutes
-                end
-              end
-
-              time_left = regular_hours_schedule.length - worked_so_far - break_length
-              header_text = time_left.positive? ? "Time left" : "Overtime"
-              time_left = time_left.abs if time_left.negative?
-              puts "#{"#{header_text}:".colorize.white.bold} #{time_left.hours} hours and #{time_left.minutes} minutes"
-            end
+            maybe_print_time_left_or_overtime(shift, worked_so_far)
           end
 
           Representers::Shift.new(shift).display
+        end
+
+        private def maybe_print_time_left_or_overtime(shift : Types::Shift, worked_so_far : Time::Span)
+          organisation = Current.config.current_environment.current_organisation!
+          regular_hours_schedule = organisation.regular_hours_schedules.try(&.find(&.day_of_week.==(shift.date.day_of_week)))
+          return unless regular_hours_schedule
+
+          break_length = begin
+            if regular_hours_schedule.breaks.any? { |regular_hours_break| break_past_current_time?(regular_hours_break) }
+              regular_hours_schedule.break_length
+            else
+              0.minutes
+            end
+          end
+
+          time_left = regular_hours_schedule.length - worked_so_far - break_length
+          header_text = time_left.positive? ? "Time left" : "Overtime"
+          time_left = time_left.abs if time_left.negative?
+          puts "#{"#{header_text}:".colorize.white.bold} #{time_left.hours} hours and #{time_left.minutes} minutes"
         end
 
         private def break_past_current_time?(regular_hours_break : RegularHoursScheduleBreak) : Bool


### PR DESCRIPTION
Extracts and expands on relevant changes from https://github.com/DanielGilchrist/tanda_cli/pull/106 which I closed as it was too messy and had a tonne of merge conflicts

<img width="585" alt="image" src="https://github.com/DanielGilchrist/tanda_cli/assets/13454550/2a85534e-c816-4653-95c5-2f3e4706a621">
<img width="582" alt="image" src="https://github.com/DanielGilchrist/tanda_cli/assets/13454550/f6b40d70-80cb-4ab4-bd54-4189da5c3352">