### PR TITLE
Fix nightly build (don't install dev dependencies for nightly)

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -26,12 +26,12 @@ jobs:
           crystal: ${{ matrix.crystal }}
 
       - name: Install shards
-        run: shards install
+        run: shards install --frozen
         if: matrix.crystal == '1.9.2'
 
       # If development shards break on nightly that's okay, we mostly only care about our app code
       - name: Install shards without development
-        run: shards install --without-development
+        run: shards install --production
         if: matrix.crystal == 'nightly'
 
       - name: Check formatting
@@ -47,4 +47,5 @@ jobs:
 
       - name: Run tests
         run: ./scripts/run-spec.sh
+        if: matrix.crystal == '1.9.2'
 

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -6,13 +6,16 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  CRYSTAL_VERSION: 1.9.2
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crystal: [1.9.2, nightly]
+        crystal: [$CRYSTAL_VERSION, nightly]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,7 +30,7 @@ jobs:
 
       - name: Install shards
         run: shards install --frozen
-        if: matrix.crystal == '1.9.2'
+        if: matrix.crystal == env.CRYSTAL_VERSION
 
       # If development shards break on nightly that's okay, we mostly only care about our app code
       - name: Install shards without development
@@ -36,16 +39,16 @@ jobs:
 
       - name: Check formatting
         run: crystal tool format; git diff --exit-code
-        if: matrix.crystal == '1.9.2'
+        if: matrix.crystal == env.CRYSTAL_VERSION
 
       - name: Lint
         run: ./bin/ameba
-        if: matrix.crystal == '1.9.2'
+        if: matrix.crystal == env.CRYSTAL_VERSION
 
       - name: Compile
         run: crystal build src/tanda_cli.cr
 
       - name: Run tests
         run: ./scripts/run-spec.sh
-        if: matrix.crystal == '1.9.2'
+        if: matrix.crystal == env.CRYSTAL_VERSION
 

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -27,10 +27,16 @@ jobs:
 
       - name: Install shards
         run: shards install
+        if: matrix.crystal == '1.9.2'
+
+      # If development shards break on nightly that's okay, we mostly only care about our app code
+      - name: Install shards without development
+        run: shards install --without-development
+        if: matrix.crystal == 'nightly'
 
       - name: Check formatting
         run: crystal tool format; git diff --exit-code
-        if: matrix.crystal == 'latest'
+        if: matrix.crystal == '1.9.2'
 
       - name: Lint
         run: ./bin/ameba

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -5,9 +5,12 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
-env:
-  CRYSTAL_VERSION: 1.9.2
+  workflow_dispatch:
+    inputs:
+      crystal_version:
+        description: "Crystal version"
+        required: false
+        default: "1.9.2"
 
 jobs:
   test:
@@ -15,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crystal: [$CRYSTAL_VERSION, nightly]
+        crystal: ["${{ inputs.crystal_version }}", nightly]
 
     runs-on: ${{ matrix.os }}
 
@@ -30,7 +33,7 @@ jobs:
 
       - name: Install shards
         run: shards install --frozen
-        if: matrix.crystal == env.CRYSTAL_VERSION
+        if: matrix.crystal == inputs.crystal_version
 
       # If development shards break on nightly that's okay, we mostly only care about our app code
       - name: Install shards without development
@@ -39,16 +42,16 @@ jobs:
 
       - name: Check formatting
         run: crystal tool format; git diff --exit-code
-        if: matrix.crystal == env.CRYSTAL_VERSION
+        if: matrix.crystal == inputs.crystal_version
 
       - name: Lint
         run: ./bin/ameba
-        if: matrix.crystal == env.CRYSTAL_VERSION
+        if: matrix.crystal == inputs.crystal_version
 
       - name: Compile
         run: crystal build src/tanda_cli.cr
 
       - name: Run tests
         run: ./scripts/run-spec.sh
-        if: matrix.crystal == env.CRYSTAL_VERSION
+        if: matrix.crystal == inputs.crystal_version
 

--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Lint
         run: ./bin/ameba
+        if: matrix.crystal == '1.9.2'
 
       - name: Compile
         run: crystal build src/tanda_cli.cr


### PR DESCRIPTION
ameba install is currently broken on nightly. Mostly only want the nightly builds to give a heads up for code in the project itself so deciding not to run dev dependencies / lint on nightly