### PR TITLE
Fix issue where `Types::Schedule` would crash when a schedule is missing `user_id`

### DIFF
--- a/src/tanda_cli/types/schedule.cr
+++ b/src/tanda_cli/types/schedule.cr
@@ -24,7 +24,7 @@ module TandaCLI
 
       getter automatic_break_length : UInt16
       getter breaks : Array(Schedule::Break)
-      getter user_id : Int32
+      getter user_id : Int32?
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/DanielGilchrist/tanda_cli/issues/109