### PR TITLE
clockin commands - Allow to match on specific photo when directory is configured

### DIFF
--- a/src/tanda_cli/commands/clock_in.cr
+++ b/src/tanda_cli/commands/clock_in.cr
@@ -20,7 +20,7 @@ module TandaCLI
       end
 
       def self.add_options(command : Cling::Command)
-        command.add_option('p', "photo", description: "Specify a clockin photo")
+        command.add_option('p', "photo", type: :single, description: "Specify a clockin photo (file path or specify photo name if directory has been set)")
         command.add_option('s', "skip-validations", description: "Skip clock in validations")
       end
 

--- a/src/tanda_cli/executors/clock_in.cr
+++ b/src/tanda_cli/executors/clock_in.cr
@@ -18,25 +18,27 @@ module TandaCLI
         end
 
         clockin_photo = @options.clockin_photo
-        parsed_photo = if clockin_photo && File.exists?(clockin_photo)
-          Models::Photo.new(clockin_photo).to_base64
-        else
-          config_photo_path = Current.config.clockin_photo_path
+        parsed_photo = begin
+          if clockin_photo && File.exists?(clockin_photo)
+            Models::Photo.new(clockin_photo).to_base64
+          else
+            config_photo_path = Current.config.clockin_photo_path
 
-          if config_photo_path
-            photo_or_dir = Models::PhotoPathParser.new(config_photo_path).parse
+            if config_photo_path
+              photo_or_dir = Models::PhotoPathParser.new(config_photo_path).parse
 
-            case photo_or_dir
-            when Models::Photo
-              photo_or_dir.to_base64
-            when Models::PhotoDirectory
-              if clockin_photo
-                photo_or_dir.find_photo(clockin_photo).try(&.to_base64)
+              case photo_or_dir
+              when Models::Photo
+                photo_or_dir.to_base64
+              when Models::PhotoDirectory
+                if clockin_photo
+                  photo_or_dir.find_photo(clockin_photo).try(&.to_base64)
+                else
+                  photo_or_dir.sample_photo.try(&.to_base64)
+                end
               else
-                photo_or_dir.sample_photo.try(&.to_base64)
+                photo_or_dir
               end
-            else
-              photo_or_dir
             end
           end
         end

--- a/src/tanda_cli/models/photo.cr
+++ b/src/tanda_cli/models/photo.cr
@@ -32,6 +32,14 @@ module TandaCLI
         end
       end
 
+      def ==(name : String) : Bool
+        @path == name
+      end
+
+      def path_includes?(name : String) : Bool
+        @path.includes?(name)
+      end
+
       private def read_and_validate_file : String | Error::Base
         photo_bytes = validate_file_exists || validate_file_type || read_file
         return photo_bytes unless photo_bytes.is_a?(String)

--- a/src/tanda_cli/models/photo.cr
+++ b/src/tanda_cli/models/photo.cr
@@ -32,10 +32,6 @@ module TandaCLI
         end
       end
 
-      def ==(name : String) : Bool
-        @path == name
-      end
-
       def path_includes?(name : String) : Bool
         @path.includes?(name)
       end

--- a/src/tanda_cli/models/photo_directory.cr
+++ b/src/tanda_cli/models/photo_directory.cr
@@ -9,16 +9,30 @@ module TandaCLI
         Dir.exists?(@path) && !!valid_photo
       end
 
+      def find_photo(name : String) : Photo?
+        valid_photo_from_name(name).tap do |photo|
+          Utils::Display.warning("No valid photo in #{@path} matching #{name}") if photo.nil?
+        end
+      end
+
       def sample_photo : Photo?
         valid_photo.tap do |photo|
           Utils::Display.warning("No valid photos found in #{@path}") if photo.nil?
         end
       end
 
+      private def valid_photo_from_name(name : String)
+        photo_names
+          .each
+          .map do |photo_name|
+            path = path_with_dir(photo_name)
+            Photo.new(path)
+          end
+          .find { |photo| (photo == name || photo.path_includes?(name)) && photo.valid? }
+      end
+
       private def valid_photo : Photo?
-        Dir
-          .open(@path)
-          .children
+        photo_names
           .shuffle
           .each
           .map do |photo_name|
@@ -26,6 +40,10 @@ module TandaCLI
             Photo.new(path)
           end
           .find(&.valid?)
+      end
+
+      private def photo_names : Array(String)
+        Dir.open(@path).children
       end
 
       private def path_with_dir(photo_name) : String

--- a/src/tanda_cli/models/photo_directory.cr
+++ b/src/tanda_cli/models/photo_directory.cr
@@ -21,29 +21,24 @@ module TandaCLI
         end
       end
 
-      private def valid_photo_from_name(name : String)
-        photo_names
-          .each
-          .map do |photo_name|
-            path = path_with_dir(photo_name)
-            Photo.new(path)
-          end
-          .find { |photo| (photo == name || photo.path_includes?(name)) && photo.valid? }
+      private def valid_photo_from_name(name : String) : Photo?
+        each_photo.find { |photo| photo.path_includes?(name) && photo.valid? }
       end
 
       private def valid_photo : Photo?
-        photo_names
-          .shuffle
+        each_photo(shuffle: true).find(&.valid?)
+      end
+
+      private def each_photo(shuffle : Bool = false)
+        Dir
+          .open(@path)
+          .children
+          .tap { |names| names.shuffle! if shuffle }
           .each
           .map do |photo_name|
             path = path_with_dir(photo_name)
             Photo.new(path)
           end
-          .find(&.valid?)
-      end
-
-      private def photo_names : Array(String)
-        Dir.open(@path).children
       end
 
       private def path_with_dir(photo_name) : String


### PR DESCRIPTION
Adds the ability to choose a specific clockin photo within the configured directory for clockins. Previously you would have to pass the full path which can be annoying

Example
```sh
# configure directory to choose random clockin photo
tanda_cli clockin set "/Users/me/Documents/my_clockin_photos/"

# match on specific photo in configured directory when clocking in
# e.g. would use /Users/me/Documents/my_clockin_photos/my_cool_photo.(jpg|png) if present and valid
tanda_cli clockin start -p "my_cool_photo" 

# can still specify photo in other directory if particular directory is configured
tanda_cli clockin start -p "/Users/me/Desktop/goose.png"
```