### PR TITLE
Refactor Clockin executor / PhotoDirectory

### DIFF
--- a/src/tanda_cli/executors/clock_in.cr
+++ b/src/tanda_cli/executors/clock_in.cr
@@ -26,7 +26,7 @@ module TandaCLI
           end
         end
 
-        base64_photo.display if base64_photo.is_a?(Error::Base)
+        base64_photo.display! if base64_photo.is_a?(Error::Base)
 
         @client.send_clock_in(now, @clock_type.to_underscore, base64_photo, mobile_clockin: true).or(&.display!)
         display_success_message

--- a/src/tanda_cli/executors/clock_in.cr
+++ b/src/tanda_cli/executors/clock_in.cr
@@ -26,13 +26,10 @@ module TandaCLI
           end
         end
 
-        case base64_photo
-        when Error::Base
-          base64_photo.display!
-        else
-          @client.send_clock_in(now, @clock_type.to_underscore, base64_photo, mobile_clockin: true).or(&.display!)
-          display_success_message
-        end
+        base64_photo.display if base64_photo.is_a?(Error::Base)
+
+        @client.send_clock_in(now, @clock_type.to_underscore, base64_photo, mobile_clockin: true).or(&.display!)
+        display_success_message
       end
 
       private def base64_photo_from_clockin_photo_path(clockin_photo : String?) : String? | Error::Base

--- a/src/tanda_cli/executors/clock_in.cr
+++ b/src/tanda_cli/executors/clock_in.cr
@@ -18,36 +18,43 @@ module TandaCLI
         end
 
         clockin_photo = @options.clockin_photo
-        parsed_photo = begin
+        base64_photo = begin
           if clockin_photo && File.exists?(clockin_photo)
             Models::Photo.new(clockin_photo).to_base64
           else
-            config_photo_path = Current.config.clockin_photo_path
-
-            if config_photo_path
-              photo_or_dir = Models::PhotoPathParser.new(config_photo_path).parse
-
-              case photo_or_dir
-              when Models::Photo
-                photo_or_dir.to_base64
-              when Models::PhotoDirectory
-                if clockin_photo
-                  photo_or_dir.find_photo(clockin_photo)
-                else
-                  photo_or_dir.sample_photo
-                end.try(&.to_base64)
-              else
-                photo_or_dir
-              end
-            end
+            base64_photo_from_clockin_photo_path(clockin_photo)
           end
         end
 
-        parsed_photo.display! if parsed_photo.is_a?(Error::Base)
+        case base64_photo
+        when Error::Base
+          base64_photo.display!
+        else
+          @client.send_clock_in(now, @clock_type.to_underscore, base64_photo, mobile_clockin: true).or(&.display!)
+          display_success_message
+        end
+      end
 
-        @client.send_clock_in(now, @clock_type.to_underscore, parsed_photo, mobile_clockin: true).or(&.display!)
+      private def base64_photo_from_clockin_photo_path(clockin_photo : String?) : String? | Error::Base
+        clockin_photo_path = Current.config.clockin_photo_path
+        return if clockin_photo_path.nil?
 
-        display_success_message
+        case photo_or_dir = Models::PhotoPathParser.new(clockin_photo_path).parse
+        when Models::PhotoDirectory
+          if clockin_photo
+            photo_or_dir.find_photo(clockin_photo).tap do |maybe_photo|
+              Utils::Display.warning("No valid photo in #{clockin_photo_path} matching #{clockin_photo}") if maybe_photo.nil?
+            end
+          else
+            photo_or_dir.sample_photo.tap do |maybe_photo|
+              Utils::Display.warning("No valid photos found in #{clockin_photo_path}") if maybe_photo.nil?
+            end
+          end.try(&.to_base64)
+        when Models::Photo
+          photo_or_dir.to_base64
+        else
+          photo_or_dir
+        end
       end
 
       private def display_success_message

--- a/src/tanda_cli/executors/clock_in.cr
+++ b/src/tanda_cli/executors/clock_in.cr
@@ -40,6 +40,8 @@ module TandaCLI
         return if clockin_photo_path.nil?
 
         case photo_or_dir = Models::PhotoPathParser.new(clockin_photo_path).parse
+        when Models::Photo
+          photo_or_dir.to_base64
         when Models::PhotoDirectory
           if clockin_photo
             photo_or_dir.find_photo(clockin_photo).tap do |maybe_photo|
@@ -50,8 +52,6 @@ module TandaCLI
               Utils::Display.warning("No valid photos found in #{clockin_photo_path}") if maybe_photo.nil?
             end
           end.try(&.to_base64)
-        when Models::Photo
-          photo_or_dir.to_base64
         else
           photo_or_dir
         end

--- a/src/tanda_cli/models/photo_directory.cr
+++ b/src/tanda_cli/models/photo_directory.cr
@@ -6,26 +6,14 @@ module TandaCLI
       def initialize(@path : String); end
 
       def valid? : Bool
-        Dir.exists?(@path) && !!valid_photo
+        Dir.exists?(@path) && !!sample_photo
       end
 
       def find_photo(name : String) : Photo?
-        valid_photo_from_name(name).tap do |photo|
-          Utils::Display.warning("No valid photo in #{@path} matching #{name}") if photo.nil?
-        end
-      end
-
-      def sample_photo : Photo?
-        valid_photo.tap do |photo|
-          Utils::Display.warning("No valid photos found in #{@path}") if photo.nil?
-        end
-      end
-
-      private def valid_photo_from_name(name : String) : Photo?
         each_photo.find { |photo| photo.path_includes?(name) && photo.valid? }
       end
 
-      private def valid_photo : Photo?
+      def sample_photo : Photo?
         each_photo(shuffle: true).find(&.valid?)
       end
 


### PR DESCRIPTION
Refactors `Models::PhotoDirectory` so that it's not responsible for displaying warnings about invalid photos. Also refactored `Executors::ClockIn` while I was at it to be a bit less of a mess